### PR TITLE
feat(rendered): Support rendered resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,6 +1106,7 @@ dependencies = [
  "config",
  "dicom",
  "dicom-json",
+ "dicom-pixeldata",
  "futures",
  "mime",
  "multer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,11 @@ version = "0.3.0-beta.1"
 description = "A robust DICOMweb server with swappable backend"
 edition = "2021"
 rust-version = "1.74.0"
-categories = ["multimedia", "network-programming", "web-programming::http-server"]
+categories = [
+  "multimedia",
+  "network-programming",
+  "web-programming::http-server",
+]
 keywords = ["dicom", "dicomweb", "healthcare", "medical"]
 repository = "https://github.com/UMEssen/DICOM-RST"
 license = "MIT"
@@ -20,6 +24,7 @@ s3 = []
 # DICOM processing
 dicom = "0.8.0"
 dicom-json = "0.8.0"
+dicom-pixeldata = { version = "0.8.0", features = ["image"] }
 sentry = { version = "0.35.0", features = ["tracing"] }
 
 # Serialization

--- a/README.md
+++ b/README.md
@@ -62,11 +62,23 @@ https://www.dicomstandard.org/using/dicomweb/retrieve-wado-rs-and-wado-uri
 
 #### Rendered Resources
 
-❌ Rendered Resourced are not supported.
+| Description      | Path                                                            | Support Status |
+|------------------|-----------------------------------------------------------------|:--------------:|
+| Study Instances  | `studies/{study}/rendered`                                      |       ✅        |
+| Series Instances | `studies/{study}/series/{series}/rendered`                      |       ✅        |
+| Instance         | `studies/{study}/series/{series}/instances/{instance}/rendered` |       ✅        |
+
+For rendering the first instance with pixeldata is used
 
 #### Thumbnail Resources
 
-❌ Thumbnail Resources are not supported.
+| Description      | Path                                                             | Support Status |
+|------------------|------------------------------------------------------------------|:--------------:|
+| Study Instances  | `studies/{study}/thumbnail`                                      |       ✅        |
+| Series Instances | `studies/{study}/series/{series}/thumbnail`                      |       ✅        |
+| Instance         | `studies/{study}/series/{series}/instances/{instance}/thumbnail` |       ✅        |
+
+The thumbnail resources just perform a 303 redirect to their rendered counterparts
 
 #### Bulkdata Resources
 

--- a/src/backend/s3/wado.rs
+++ b/src/backend/s3/wado.rs
@@ -1,4 +1,7 @@
-use crate::api::wado::{InstanceResponse, RetrieveError, RetrieveInstanceRequest, WadoService};
+use crate::api::wado::{
+	InstanceResponse, RenderedRequest, RenderedResponse, RetrieveError, RetrieveInstanceRequest,
+	WadoService,
+};
 use crate::backend::dimse::cmove::movescu::MoveError;
 use crate::config::{S3Config, S3EndpointStyle};
 use async_trait::async_trait;
@@ -114,5 +117,9 @@ impl WadoService for S3WadoService {
 		Ok(InstanceResponse {
 			stream: stream.boxed(),
 		})
+	}
+
+	async fn render(&self, _request: RenderedRequest) -> Result<RenderedResponse, RetrieveError> {
+		unimplemented!()
 	}
 }


### PR DESCRIPTION
This implements #9 

Current behaviour is that the /rendered endpoints return the first renderable instance from the related study / series. According to the specification the behaviour doesn't follow any rules - it must just be documented within the conformance statement

Right for for the windowing the LUT function is ignored, since my PR is not in a released `dicom-rs` version yet: https://github.com/Enet4/dicom-rs/pull/598