### PR TITLE
Disable S3 dependencies when `s3` feature is disabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,8 @@ license = "MIT"
 readme = "README.md"
 
 [features]
-default = ["dimse", "s3"]
-dimse = []
-# TODO: feature-gate S3 dependencies
-s3 = []
+default = []
+s3 = ["dep:aws-config", "dep:aws-sdk-s3", "dep:aws-credential-types"]
 
 [dependencies]
 # DICOM processing
@@ -54,9 +52,9 @@ multer = "3.1.0"
 pin-project = "1.1.10"
 image = { version = "0.25.6", features = ["png", "jpeg", "gif"] }
 # S3 backend
-aws-config = { version = "1.6.2", features = ["behavior-version-latest"] }
-aws-sdk-s3 = "1.85.0"
-aws-credential-types = "1.2.3"
+aws-config = { version = "1.6.2", features = ["behavior-version-latest"], optional = true }
+aws-sdk-s3 = { version = "1.85.0", optional = true }
+aws-credential-types = { version = "1.2.3", optional = true }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,20 +1,14 @@
 use crate::api::qido::QidoService;
 use crate::api::stow::StowService;
 use crate::api::wado::WadoService;
-use crate::backend::dimse::qido::DimseQidoService;
-use crate::backend::dimse::stow::DimseStowService;
-use crate::backend::dimse::wado::DimseWadoService;
-use crate::backend::s3::wado::S3WadoService;
 use crate::config::BackendConfig;
 use crate::AppState;
-use async_trait::async_trait;
 use axum::extract::{FromRef, FromRequestParts, Path};
 use axum::http::request::Parts;
 use axum::http::StatusCode;
 use serde::Deserialize;
 use std::time::Duration;
 
-// #[cfg(feature = "dimse")]
 pub mod dimse;
 
 #[cfg(feature = "s3")]
@@ -54,8 +48,11 @@ where
 
 		// TODO: Use a singleton to avoid re-creating on every request.
 		let provider = match ae_config.backend {
-			#[cfg(feature = "dimse")]
 			BackendConfig::Dimse { .. } => {
+				use crate::backend::dimse::qido::DimseQidoService;
+				use crate::backend::dimse::stow::DimseStowService;
+				use crate::backend::dimse::wado::DimseWadoService;
+
 				let pool = state.pools.get(&ae_config.aet).expect("pool should exist");
 
 				Self {
@@ -75,19 +72,16 @@ where
 					))),
 				}
 			}
-			// For some reason serde doesn't work with feature-gated enum variants.
-			// A no-op backend is used as a workaround if the dimse feature is not enabled.
-			#[cfg(not(feature = "dimse"))]
-			Backend::Dimse => Self {
-				qido: None,
-				wado: None,
-				stow: None,
-			},
-			BackendConfig::S3(config) => Self {
-				qido: None,
-				wado: Some(Box::new(S3WadoService::new(&config))),
-				stow: None,
-			},
+			#[cfg(feature = "s3")]
+			BackendConfig::S3(config) => {
+				use crate::backend::s3::wado::S3WadoService;
+
+				Self {
+					qido: None,
+					wado: Some(Box::new(S3WadoService::new(&config))),
+					stow: None,
+				}
+			}
 		};
 
 		Ok(provider)

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,9 +57,7 @@ fn init_logger(level: tracing::Level) {
 #[derive(Clone)]
 pub struct AppState {
 	pub config: AppConfig,
-	#[cfg(feature = "dimse")]
 	pub pools: AssociationPools,
-	#[cfg(feature = "dimse")]
 	pub mediator: MoveMediator,
 }
 
@@ -102,20 +100,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn run(config: AppConfig) -> anyhow::Result<()> {
-	#[cfg(feature = "dimse")]
 	let mediator = MoveMediator::new(&config);
-	#[cfg(feature = "dimse")]
 	let pools = AssociationPools::new(&config);
 
 	let app_state = AppState {
 		config: config.clone(),
-		#[cfg(feature = "dimse")]
 		mediator: mediator.clone(),
-		#[cfg(feature = "dimse")]
 		pools,
 	};
 
-	#[cfg(feature = "dimse")]
 	for dimse_config in config.server.dimse {
 		let mediator = mediator.clone();
 		let subscribers: Vec<AE> = config


### PR DESCRIPTION
Fixes #33.

This also makes the DIMSE backend mandatory for now. The crate feature `dimse` was removed as the project didn't compile without it. In a future version, we'll revisit this to make the DIMSE backend optional as well. This allows for use cases where users only need the S3 backend for example. 