### PR TITLE
feat(transcode): support transcoding

### DIFF
--- a/src/api/wado/routes.rs
+++ b/src/api/wado/routes.rs
@@ -70,6 +70,7 @@ async fn instance_resource(
 	request: RetrieveInstanceRequest,
 ) -> impl IntoResponse {
 	if let Some(wado) = provider.wado {
+		let transfer_syntax = request.transfer_syntax.clone();
 		let study_instance_uid: UI = request.query.study_instance_uid.clone();
 		let response = wado.retrieve(request).await;
 
@@ -92,6 +93,7 @@ async fn instance_resource(
 					)
 					.body(Body::from_stream(DicomMultipartStream::new(
 						stream.into_stream(),
+						transfer_syntax.as_deref(),
 					)))
 					.unwrap()
 			}
@@ -131,6 +133,7 @@ async fn rendered_resource(
 			trace!("Using default rendering");
 			let instance_request = RetrieveInstanceRequest {
 				query: request.query,
+				transfer_syntax: None,
 			};
 
 			let stream = wado

--- a/src/api/wado/service.rs
+++ b/src/api/wado/service.rs
@@ -52,10 +52,10 @@ pub enum RetrieveError {
 impl IntoResponse for RetrieveError {
 	fn into_response(self) -> Response {
 		match self {
-			RetrieveError::Backend { source } => {
+			Self::Backend { source } => {
 				(StatusCode::INTERNAL_SERVER_ERROR, source.to_string()).into_response()
 			}
-			RetrieveError::Unimplemented => Response::builder()
+			Self::Unimplemented => Response::builder()
 				.status(StatusCode::NOT_IMPLEMENTED)
 				.body(Body::from("This transaction is not implemented."))
 				.unwrap(),
@@ -160,7 +160,7 @@ where
 
 /// Extracts the transfer-syntax parameter from an Accept header value.
 ///
-/// According to https://dicom.nema.org/medical/dicom/current/output/chtml/part18/sect_8.7.3.5.2.html
+/// According to <https://dicom.nema.org/medical/dicom/current/output/chtml/part18/sect_8.7.3.5.2.html>
 /// the syntax is: transfer-syntax-mtp = OWS ";" OWS %s"transfer-syntax=" ts-value
 ///
 /// Examples:

--- a/src/api/wado/service.rs
+++ b/src/api/wado/service.rs
@@ -64,6 +64,7 @@ impl IntoResponse for RetrieveError {
 }
 pub struct RetrieveInstanceRequest {
 	pub query: ResourceQuery,
+	pub transfer_syntax: Option<String>,
 }
 
 pub struct ThumbnailRequest {
@@ -157,6 +158,33 @@ where
 	}
 }
 
+/// Extracts the transfer-syntax parameter from an Accept header value.
+///
+/// According to https://dicom.nema.org/medical/dicom/current/output/chtml/part18/sect_8.7.3.5.2.html
+/// the syntax is: transfer-syntax-mtp = OWS ";" OWS %s"transfer-syntax=" ts-value
+///
+/// Examples:
+/// - "application/dicom; transfer-syntax=1.2.840.10008.1.2.4.50"
+/// - "multipart/related; type=\"application/dicom\"; transfer-syntax=1.2.840.10008.1.2.4.50"
+fn extract_transfer_syntax_from_accept(accept_header: &str) -> Option<String> {
+	// Split by semicolons to get individual parameters
+	for part in accept_header.split(';') {
+		let trimmed = part.trim();
+		// Look for the transfer-syntax parameter
+		if let Some(value) = trimmed.strip_prefix("transfer-syntax=") {
+			let value = value.trim();
+			// The value might be quoted or unquoted
+			let transfer_syntax = if value.starts_with('"') && value.ends_with('"') {
+				value.trim_matches('"')
+			} else {
+				value
+			};
+			return Some(transfer_syntax.to_string());
+		}
+	}
+	None
+}
+
 impl<S> FromRequestParts<S> for RetrieveInstanceRequest
 where
 	AppState: FromRef<S>,
@@ -169,7 +197,21 @@ where
 			.await
 			.map_err(PathRejection::into_response)?;
 
-		Ok(Self { query })
+		let accept = parts
+			.headers
+			.get(ACCEPT)
+			.map(|h| String::from(h.to_str().unwrap_or_default()));
+
+		// Extract the requested transfer-syntax from the Accept header if present
+		// https://dicom.nema.org/medical/dicom/current/output/chtml/part18/sect_8.7.3.5.2.html
+		let transfer_syntax = accept
+			.as_ref()
+			.and_then(|accept_str| extract_transfer_syntax_from_accept(accept_str));
+
+		Ok(Self {
+			query,
+			transfer_syntax,
+		})
 	}
 }
 
@@ -453,6 +495,59 @@ mod tests {
 		assert_eq!(
 			"0".parse::<ImageQuality>().unwrap(),
 			ImageQuality::new(0).unwrap()
+		);
+	}
+
+	#[test]
+	fn test_extract_transfer_syntax_from_accept() {
+		// Test simple case
+		assert_eq!(
+			extract_transfer_syntax_from_accept(
+				"application/dicom; transfer-syntax=1.2.840.10008.1.2.4.50"
+			),
+			Some("1.2.840.10008.1.2.4.50".to_string())
+		);
+
+		// Test with extra whitespace
+		assert_eq!(
+			extract_transfer_syntax_from_accept(
+				"application/dicom;   transfer-syntax=1.2.840.10008.1.2.4.50"
+			),
+			Some("1.2.840.10008.1.2.4.50".to_string())
+		);
+
+		// Test wildcard
+		assert_eq!(
+			extract_transfer_syntax_from_accept("application/dicom; transfer-syntax=*"),
+			Some("*".to_string())
+		);
+
+		// Test multipart/related with type parameter
+		assert_eq!(
+			extract_transfer_syntax_from_accept("multipart/related; type=\"application/dicom\"; transfer-syntax=1.2.840.10008.1.2.4.50"),
+			Some("1.2.840.10008.1.2.4.50".to_string())
+		);
+
+		// Test with quoted value (though not typical for transfer-syntax)
+		assert_eq!(
+			extract_transfer_syntax_from_accept(
+				"application/dicom; transfer-syntax=\"1.2.840.10008.1.2.4.50\""
+			),
+			Some("1.2.840.10008.1.2.4.50".to_string())
+		);
+
+		// Test without transfer-syntax parameter
+		assert_eq!(
+			extract_transfer_syntax_from_accept("application/dicom"),
+			None
+		);
+
+		// Test with other parameters but no transfer-syntax
+		assert_eq!(
+			extract_transfer_syntax_from_accept(
+				"multipart/related; type=\"application/dicom\"; boundary=example"
+			),
+			None
 		);
 	}
 

--- a/src/backend/dimse/cmove/movescu.rs
+++ b/src/backend/dimse/cmove/movescu.rs
@@ -87,6 +87,8 @@ pub enum MoveError {
 	#[error(transparent)]
 	Write(#[from] WriteError),
 	#[error(transparent)]
+	Transcode(#[from] dicom::pixeldata::TranscodeError),
+	#[error(transparent)]
 	Association(#[from] PoolError<AssociationError>),
 	#[error("Sub-operation failed")]
 	OperationFailed,

--- a/src/backend/dimse/wado.rs
+++ b/src/backend/dimse/wado.rs
@@ -308,8 +308,13 @@ impl<'a> DicomMultipartStream<'a> {
 		let mut buffer = Vec::new();
 
 		writeln!(buffer, "--boundary\r")?;
-		writeln!(buffer, "Content-Type: application/dicom\r")?;
-		writeln!(buffer, "Content-Length: {file_length}\r")?;
+		writeln!(
+			buffer,
+			"Content-Type: {}; transfer-syntax=\"{}\"\r",
+			"application/dicom",
+			file.meta().transfer_syntax
+		)?;
+		writeln!(buffer, "Content-Length: {}\r", file_length)?;
 		writeln!(buffer, "\r")?;
 		buffer.append(&mut dcm);
 		writeln!(buffer, "\r")?;

--- a/src/backend/dimse/wado.rs
+++ b/src/backend/dimse/wado.rs
@@ -312,7 +312,7 @@ impl<'a> DicomMultipartStream<'a> {
 			buffer,
 			"Content-Type: {}; transfer-syntax=\"{}\"\r",
 			"application/dicom",
-			file.meta().transfer_syntax
+			file.meta().transfer_syntax.trim_end_matches('\0')
 		)?;
 		writeln!(buffer, "Content-Length: {}\r", file_length)?;
 		writeln!(buffer, "\r")?;


### PR DESCRIPTION
Implements #10 

Without transcoding:
<img width="1490" height="812" alt="image" src="https://github.com/user-attachments/assets/0d732f8c-222f-4ba6-ae13-873b6e214d87" />



With transcoding:
<img width="1490" height="812" alt="image" src="https://github.com/user-attachments/assets/a28b87d8-dab2-4d36-a402-61dd0b20c868" />


See supported transfer syntaxes here: https://docs.rs/dicom-transfer-syntax-registry/latest/dicom_transfer_syntax_registry/#transfer-syntaxes (thanks @Enet4  for the hint)